### PR TITLE
Fix useEffect missing dependency router

### DIFF
--- a/pages/404.js
+++ b/pages/404.js
@@ -7,9 +7,10 @@ const PageNotFound = () => {
 
 	useEffect(() => {
 		setTimeout(() => {
+			console.log(router)
 			router.push('/')
 		}, 3000)
-	}, [])
+	}, [router])
 
 	return (
 		<>


### PR DESCRIPTION
## Description

```javascript
	useEffect(() => {
		setTimeout(() => {
			console.log(router)
			router.push('/')
		}, 3000)
	}, [])
```

The empty dependecy causing a warning of `react hook useeffect missing depedency router`.
Following the quick fix suggestion, we need to include the `router` in the dependency as below.

```javascript
	useEffect(() => {
		setTimeout(() => {
			console.log(router)
			router.push('/')
		}, 3000)
	}, [router])
```

## Resources

- [[ESLint] Feedback for 'exhaustive-deps' lint rule](https://github.com/facebook/react/issues/14920)
